### PR TITLE
Remplacement des caractères accentués par leur équivalent ASCII et les quotes par des espaces

### DIFF
--- a/src/app/components/articles/articles.component.ts
+++ b/src/app/components/articles/articles.component.ts
@@ -86,7 +86,14 @@ export class ArticlesComponent implements OnInit, AfterViewInit {
   }
 
   applyFilter(filterValue: string) {
-    this.dataSource.filter = filterValue.trim().toLowerCase();
+    // Replace accentued chars by their ASCII equivalent and replace quotes by spaces
+    let normalized = filterValue
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace('\'', ' ')
+      .trim()
+      .toLowerCase();
+    this.dataSource.filter = normalized;
     if (this.dataSource.paginator) {
       this.dataSource.paginator.firstPage();
     }


### PR DESCRIPTION
La base Kaso stocke tous les noms sans accent et avec un espace au lieu des apostrophes