### PR TITLE
refactor(Localhost): pouvoir faire tourner le frontend sans le backend, en skippant oauth2

### DIFF
--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,9 +1,10 @@
 import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot} from '@angular/router';
-import {Observable} from 'rxjs';
+import {Observable, of} from 'rxjs';
 import {HttpClient} from '@angular/common/http';
 import {map} from 'rxjs/operators';
 import {SessionService} from '../services/session.service';
+import {environment} from '../../environments/environment';
 
 export interface UserStatus {
   logged: boolean;
@@ -27,6 +28,22 @@ export class AuthGuard implements CanActivate {
   }
 
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+    if (environment.authBypass) {
+      const userStatus: UserStatus = {
+        logged: true,
+        oauth_url: '/api/connect/custom',
+        disconnect_url: '/api/logout',
+        logout_page_url: location.origin,
+        vip_ip: true,
+        user: {
+          username: 'dev.local'
+        }
+      };
+
+      this.sessionService.updateUserStatus(userStatus);
+      return of(true);
+    }
+
     return this.http.get<UserStatus>('/api/user/status').pipe(map(
       (userStatus: UserStatus) => {
         if (userStatus.logged) {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  barcodeScanner: false
+  barcodeScanner: false,
+  authBypass: false
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,8 @@
 
 export const environment = {
   production: false,
-  barcodeScanner: true
+  barcodeScanner: true,
+  authBypass: true
 };
 
 /*


### PR DESCRIPTION
### Quoi

En local, on est actuellement obligé de faire tourner l'app backend en parallèle.
Sauf que c'est soit compliqué, soit y'a simplement aucune données.

Cette PR permet de faire tourner le frontend seulement, en se connectant à l'API de prod.
(en modifiant `proxy.conf.json`)