### PR TITLE
feat: récupérer les produits dès le chargement. Et les garder en cache pour éviter trop d'appels API

### DIFF
--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,4 +1,5 @@
 import {Component, OnInit} from '@angular/core';
+import {ArticlesService} from '../../services/articles.service';
 
 export interface MenuItem {
   url: string;
@@ -49,10 +50,12 @@ export class HomeComponent implements OnInit {
     }
   ];
 
-  constructor() {
+  constructor(private articleService: ArticlesService) {
   }
 
   ngOnInit() {
+    // Preload articles in the background
+    this.articleService.getArticles().subscribe();
   }
 
 }

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -1,5 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {ArticlesService} from '../../services/articles.service';
+import {LoadingService} from '../../services/loading.service';
 
 export interface MenuItem {
   url: string;
@@ -50,12 +51,21 @@ export class HomeComponent implements OnInit {
     }
   ];
 
-  constructor(private articleService: ArticlesService) {
+  constructor(private articleService: ArticlesService, private loadingService: LoadingService) {
   }
 
   ngOnInit() {
     // Preload articles in the background
-    this.articleService.getArticles().subscribe();
+    this.loadingService.taskStarted();
+    this.articleService.getArticles().subscribe(
+      () => {
+        this.loadingService.taskFinished();
+      },
+      err => {
+        console.error(err);
+        this.loadingService.taskFinished();
+      }
+    );
   }
 
 }

--- a/src/app/services/articles.service.ts
+++ b/src/app/services/articles.service.ts
@@ -1,22 +1,39 @@
 import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
-import {Observable} from 'rxjs';
+import {Observable, of} from 'rxjs';
+import {tap} from 'rxjs/operators';
 import {Article} from '../models/article';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ArticlesService {
+  private articlesCache: Article[] | null = null;
 
   constructor(private http: HttpClient) {
   }
 
   getArticles(): Observable<Article[]> {
-    return this.http.get<Article[]>('/api/articles');
+    // Return cached articles if available
+    if (this.articlesCache) {
+      return of(this.articlesCache);
+    }
+
+    // Otherwise fetch from API
+    return this.http.get<Article[]>('/api/articles').pipe(
+      tap(articles => {
+        this.articlesCache = articles;  // Store in cache
+      })
+    );
   }
 
   getArticle(articleId: number): Observable<Article> {
     return this.http.get<Article>('/api/articles/' + articleId);
+  }
+
+  refreshArticles(): Observable<Article[]> {
+    this.articlesCache = null;  // Clear cache
+    return this.getArticles();
   }
 
 }

--- a/src/app/services/articles.service.ts
+++ b/src/app/services/articles.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable, of} from 'rxjs';
-import {tap} from 'rxjs/operators';
+import {tap, shareReplay} from 'rxjs/operators';
 import {Article} from '../models/article';
 
 @Injectable({
@@ -19,11 +19,14 @@ export class ArticlesService {
       return of(this.articlesCache);
     }
 
-    // Otherwise fetch from API
+    // Otherwise fetch from API - share the request among multiple subscribers
     return this.http.get<Article[]>('/api/articles').pipe(
       tap(articles => {
-        this.articlesCache = articles;  // Store in cache
-      })
+        // Store in cache
+        this.articlesCache = articles;
+      }),
+      // Share the same request if multiple subscribers
+      shareReplay(1)
     );
   }
 
@@ -32,7 +35,8 @@ export class ArticlesService {
   }
 
   refreshArticles(): Observable<Article[]> {
-    this.articlesCache = null;  // Clear cache
+    // Clear cache and fetch fresh articles from API
+    this.articlesCache = null;
     return this.getArticles();
   }
 

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -2,13 +2,14 @@ import {Injectable} from '@angular/core';
 import {UserStatus} from '../guards/auth.guard';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {ArticlesService} from './articles.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class SessionService {
 
-  constructor(private http: HttpClient) {
+  constructor(private http: HttpClient, private articlesService: ArticlesService) {
   }
 
   private _userStatusSubject: BehaviorSubject<UserStatus> = new BehaviorSubject<UserStatus>(null);
@@ -18,12 +19,18 @@ export class SessionService {
   }
 
   updateUserStatus(status: UserStatus) {
+    // Clear cache when user status changes (sign in/out)
+    if (status !== this._userStatusSubject.value) {
+      this.articlesService.refreshArticles().subscribe();
+    }
     this._userStatusSubject.next(status);
   }
 
   disconnect(status: UserStatus): void {
     this.http.get<any>(status.disconnect_url).subscribe(
       (ret: any) => {
+        // Clear cache on disconnect
+        this.articlesService.refreshArticles().subscribe();
         this.updateUserStatus(null);
         window.location.href = status.logout_page_url;
       },


### PR DESCRIPTION
La liste des articles change toutes les nuits, donc pas besoin d'aller récupérer les données à chaque changement de page.
On rajoute aussi un chargement sur la home page (avec loader).
Et si l'utilisateur change de page alors que le loading est toujours en cours, on évite de faire un 2e appel API